### PR TITLE
Adjust header opacity based on scroll position

### DIFF
--- a/site/assets/themes/fw-child/resources/js/child-functions.js
+++ b/site/assets/themes/fw-child/resources/js/child-functions.js
@@ -15,6 +15,15 @@ var child_logging = true
 
     $(document).data('child_theme_dir', child_theme_dir)
 
+		// Scroll event handler
+		$(window).scroll(function() {		
+			if ($(this).scrollTop() > 50) {
+				$('#main-header').css('background-color', 'rgba(236, 241, 244, 1)');
+			} else {
+				$('#main-header').css('background-color', 'rgba(236, 241, 244, 0.5)');
+			}
+		});
+	
 		//
 		// HEADER
 		//
@@ -189,7 +198,6 @@ var child_logging = true
 			})
 			
 		}
-
     if (child_logging == true) {
       console.log('end of child-functions.js')
       console.log('- - - - -')


### PR DESCRIPTION
This PR addresses [issue #93](https://github.com/OpenDRR/riskprofiler/issues/93) from riskprofiler repository.

**Changes**
In `site/assets/themes/fw-child/resources/js/child-functions.js`, added a simple javascript logic that checks whether the position of the screen has been scrolled more than 50px. If so, the header's background colour is fully opaque. Otherwise, the header's background colour is semi-transparent.